### PR TITLE
Fix ryujinx breaking when paths have space in it

### DIFF
--- a/ryujinx-wrapper
+++ b/ryujinx-wrapper
@@ -4,4 +4,4 @@ for i in {0..9}; do
     test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
 done
 
-Ryujinx $@
+Ryujinx "$@"


### PR DESCRIPTION
This fixes [#Ryujinx/issues/3264](https://github.com/Ryujinx/Ryujinx/issues/3264)