### PR TITLE
Manual release update

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-    "only-arches": ["x86_64"],
-    "publish-delay-hours": 0
+    "only-arches": ["x86_64"]
 }

--- a/org.ryujinx.Ryujinx.appdata.xml
+++ b/org.ryujinx.Ryujinx.appdata.xml
@@ -47,6 +47,8 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release version="1.1.297" date="2022-10-08"/>
+        <release version="1.1.296" date="2022-10-08"/>
         <release version="1.1.295" date="2022-10-05"/>
         <release version="1.1.294" date="2022-10-04"/>
         <release version="1.1.293" date="2022-10-03"/>

--- a/org.ryujinx.Ryujinx.yml
+++ b/org.ryujinx.Ryujinx.yml
@@ -33,7 +33,7 @@ modules:
       PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet6/lib/pkgconfig
       DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 'true'
-      RYUJINX_VERSION: 1.1.295
+      RYUJINX_VERSION: 1.1.297
       RYUJINX_TARGET_RELEASE_CHANNEL_OWNER: flathub
       RYUJINX_TARGET_RELEASE_CHANNEL_REPO: org.ryujinx.Ryujinx
       RYUJINX_TARGET_RELEASE_CHANNEL_NAME: master
@@ -63,7 +63,7 @@ modules:
   - nuget_sources.json
   - type: git
     url: https://github.com/Ryujinx/Ryujinx.git
-    commit: 599d485bffc9080d1c54acce929bbda0c7077499
+    commit: bf77d1cab93467676156ebfbd5cf0ae057266e6f
   - type: file
     path: ryujinx-wrapper
   - type: file


### PR DESCRIPTION
Because of [changes from FlatHub to enforces a PR workflow](https://github.com/flathub/flathub/issues/3568#issuecomment-1272404533), the past two releases weren't published.

This upgrade to 1.1.297.