### PR TITLE
Update file paths & Add DOTNET_EnableAlternateStackCheck env var

### DIFF
--- a/org.ryujinx.Ryujinx.yml
+++ b/org.ryujinx.Ryujinx.yml
@@ -56,7 +56,7 @@ modules:
     ln -s /usr/lib/x86_64-linux-gnu/libX11.so.6 /app/lib/libX11.so
     install -Dm644 $FLATPAK_ID.appdata.xml /app/share/metainfo/$FLATPAK_ID.appdata.xml
     install -Dm755 ryujinx-wrapper /app/bin/ryujinx-wrapper
-    install -Dm644 distribution/misc/Logo.svg /app/share/icons/hicolor/scalable/apps/ryujinx.svg
+    install -Dm644 distribution/misc/Logo.svg /app/share/icons/hicolor/scalable/apps/Ryujinx.svg
     install -Dm644 distribution/linux/mime/Ryujinx.xml /app/share/mime/packages/$FLATPAK_ID.mime.xml
     install -Dm644 distribution/linux/Ryujinx.desktop /app/share/applications/$FLATPAK_ID.desktop
     desktop-file-edit --set-key="Exec" --set-value="ryujinx-wrapper %f" /app/share/applications/$FLATPAK_ID.desktop

--- a/org.ryujinx.Ryujinx.yml
+++ b/org.ryujinx.Ryujinx.yml
@@ -56,9 +56,9 @@ modules:
     ln -s /usr/lib/x86_64-linux-gnu/libX11.so.6 /app/lib/libX11.so
     install -Dm644 $FLATPAK_ID.appdata.xml /app/share/metainfo/$FLATPAK_ID.appdata.xml
     install -Dm755 ryujinx-wrapper /app/bin/ryujinx-wrapper
-    install -Dm644 distribution/linux/ryujinx-logo.svg /app/share/icons/hicolor/scalable/apps/ryujinx.svg
-    install -Dm644 distribution/linux/ryujinx-mime.xml /app/share/mime/packages/$FLATPAK_ID.mime.xml
-    install -Dm644 distribution/linux/ryujinx.desktop /app/share/applications/$FLATPAK_ID.desktop
+    install -Dm644 distribution/misc/Logo.svg /app/share/icons/hicolor/scalable/apps/ryujinx.svg
+    install -Dm644 distribution/linux/mime/Ryujinx.xml /app/share/mime/packages/$FLATPAK_ID.mime.xml
+    install -Dm644 distribution/linux/Ryujinx.desktop /app/share/applications/$FLATPAK_ID.desktop
     desktop-file-edit --set-key="Exec" --set-value="ryujinx-wrapper %f" /app/share/applications/$FLATPAK_ID.desktop
   sources:
   - type: archive

--- a/org.ryujinx.Ryujinx.yml
+++ b/org.ryujinx.Ryujinx.yml
@@ -41,11 +41,11 @@ modules:
     export PATH=$PATH:/run/build/Ryujinx/dotnet-sdk
     export RYUJINX_GIT_SHORT_HASH=$(git rev-parse --short HEAD)
     export RUNTIME_FRAMEWORK_VERSION=$(find nuget-sources -name 'microsoft.netcore.app.host.linux-x64.*' | grep -oP '(\d.\d.\d+.nupkg)' | grep -oP '(\d.\d.\d+)')
-    sed -r --in-place "s/\%\%RYUJINX_BUILD_VERSION\%\%/$RYUJINX_VERSION/g;" Ryujinx.Common/ReleaseInformations.cs
-    sed -r --in-place "s/\%\%RYUJINX_BUILD_GIT_HASH\%\%/$RYUJINX_GIT_SHORT_HASH/g;" Ryujinx.Common/ReleaseInformations.cs
-    sed -r --in-place "s/\%\%RYUJINX_TARGET_RELEASE_CHANNEL_NAME\%\%/$RYUJINX_TARGET_RELEASE_CHANNEL_NAME/g;" Ryujinx.Common/ReleaseInformations.cs
-    sed -r --in-place "s/\%\%RYUJINX_TARGET_RELEASE_CHANNEL_OWNER\%\%/$RYUJINX_TARGET_RELEASE_CHANNEL_OWNER/g;" Ryujinx.Common/ReleaseInformations.cs
-    sed -r --in-place "s/\%\%RYUJINX_TARGET_RELEASE_CHANNEL_REPO\%\%/$RYUJINX_TARGET_RELEASE_CHANNEL_REPO/g;" Ryujinx.Common/ReleaseInformations.cs
+    sed -r --in-place "s/\%\%RYUJINX_BUILD_VERSION\%\%/$RYUJINX_VERSION/g;" Ryujinx.Common/ReleaseInformation.cs
+    sed -r --in-place "s/\%\%RYUJINX_BUILD_GIT_HASH\%\%/$RYUJINX_GIT_SHORT_HASH/g;" Ryujinx.Common/ReleaseInformation.cs
+    sed -r --in-place "s/\%\%RYUJINX_TARGET_RELEASE_CHANNEL_NAME\%\%/$RYUJINX_TARGET_RELEASE_CHANNEL_NAME/g;" Ryujinx.Common/ReleaseInformation.cs
+    sed -r --in-place "s/\%\%RYUJINX_TARGET_RELEASE_CHANNEL_OWNER\%\%/$RYUJINX_TARGET_RELEASE_CHANNEL_OWNER/g;" Ryujinx.Common/ReleaseInformation.cs
+    sed -r --in-place "s/\%\%RYUJINX_TARGET_RELEASE_CHANNEL_REPO\%\%/$RYUJINX_TARGET_RELEASE_CHANNEL_REPO/g;" Ryujinx.Common/ReleaseInformation.cs
     mkdir -p /app/bin
     dotnet publish -c Release -r $RUNTIME /p:DebugType=embedded Ryujinx /p:Version=$RYUJINX_VERSION /p:SourceRevisionId=$RYUJINX_GIT_SHORT_HASH /p:ExtraDefineConstants=DISABLE_UPDATER /p:RuntimeFrameworkVersion=$RUNTIME_FRAMEWORK_VERSION --self-contained --source nuget-sources
     if [ $? -ne 0 ]; then

--- a/ryujinx-wrapper
+++ b/ryujinx-wrapper
@@ -4,4 +4,4 @@ for i in {0..9}; do
     test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
 done
 
-Ryujinx "$@"
+env DOTNET_EnableAlternateStackCheck=1 Ryujinx "$@"


### PR DESCRIPTION
This PR updates the file paths for the distribution directory which are getting changed soon.
Aside from that the env var `DOTNET_EnableAlternateStackCheck=1` was added to ryujinx-wrapper, so Ryujinx will always be launched with it enabled.

---

Depends on Ryujinx/Ryujinx#4013 