### PR TITLE
Replace x-checker-data type with rotating-url

### DIFF
--- a/org.ryujinx.Ryujinx.yml
+++ b/org.ryujinx.Ryujinx.yml
@@ -65,13 +65,12 @@ modules:
     only-arches:
     - x86_64
     dest: dotnet-sdk
-    url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.201/dotnet-sdk-7.0.201-linux-x64.tar.gz
+    url: https://dotnetcli.azureedge.net/dotnet/Sdk/7.0.201/dotnet-sdk-7.0.201-linux-x64.tar.gz
     sha256: e74ccc69a299b0e9267f812ca6bd60eaa479dc5f844b3be68b04358a0f4e10f3
     x-checker-data:
-      type: html
-      url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0/latest.version
-      version-pattern: ^([\d\.a-z-]+)$
-      url-template: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-linux-x64.tar.gz
+      type: rotating-url
+      url: https://aka.ms/dotnet/7.0/dotnet-sdk-linux-x64.tar.gz
+      pattern: https://dotnetcli.azureedge.net/dotnet/Sdk/^([\d\.a-z-]+)$/dotnet-sdk-^([\d\.a-z-]+)$-linux-x64.tar.gz
   - nuget_sources.json
   - type: git
     url: https://github.com/Ryujinx/Ryujinx.git

--- a/org.ryujinx.Ryujinx.yml
+++ b/org.ryujinx.Ryujinx.yml
@@ -65,8 +65,8 @@ modules:
     only-arches:
     - x86_64
     dest: dotnet-sdk
-    url: https://dotnetcli.azureedge.net/dotnet/Sdk/7.0.201/dotnet-sdk-7.0.201-linux-x64.tar.gz
-    sha256: e74ccc69a299b0e9267f812ca6bd60eaa479dc5f844b3be68b04358a0f4e10f3
+    url: https://dotnetcli.azureedge.net/dotnet/Sdk/7.0.202/dotnet-sdk-7.0.202-linux-x64.tar.gz
+    sha256: 405f15e437582be260460f48eda9dfe613fd87b2557667f20d6ecfa34b09c221
     x-checker-data:
       type: rotating-url
       url: https://aka.ms/dotnet/7.0/dotnet-sdk-linux-x64.tar.gz


### PR DESCRIPTION
The current method still reports 7.0.201 as the latest sdk version, although it should be reporting 7.0.202.

The method used by this PR is also used by the dotnet-install.sh script, so it should always answer with the latest version.