### PR TITLE
Use Ryujinx.sh & grant write access to pictures directory

### DIFF
--- a/org.ryujinx.Ryujinx.yml
+++ b/org.ryujinx.Ryujinx.yml
@@ -14,6 +14,7 @@ finish-args:
 - --socket=pulseaudio
 - --share=network
 - --filesystem=home:ro
+- --filesystem=xdg-pictures:rw
 - --filesystem=xdg-run/app/com.discordapp.Discord:create
 rename-icon: ryujinx
 command: ryujinx-wrapper

--- a/org.ryujinx.Ryujinx.yml
+++ b/org.ryujinx.Ryujinx.yml
@@ -60,7 +60,6 @@ modules:
     ln -s /usr/lib/x86_64-linux-gnu/libX11.so.6 /app/lib/libX11.so
     install -Dm644 $FLATPAK_ID.appdata.xml /app/share/metainfo/$FLATPAK_ID.appdata.xml
     install -Dm755 ryujinx-wrapper /app/bin/ryujinx-wrapper
-    install -Dm755 distribution/linux/Ryujinx.sh /app/bin/Ryujinx.sh
     install -Dm644 distribution/misc/Logo.svg /app/share/icons/hicolor/scalable/apps/ryujinx.svg
     install -Dm644 distribution/linux/mime/Ryujinx.xml /app/share/mime/packages/$FLATPAK_ID.mime.xml
     install -Dm644 distribution/linux/Ryujinx.desktop /app/share/applications/$FLATPAK_ID.desktop

--- a/org.ryujinx.Ryujinx.yml
+++ b/org.ryujinx.Ryujinx.yml
@@ -48,7 +48,7 @@ modules:
     sed -r --in-place "s/\%\%RYUJINX_TARGET_RELEASE_CHANNEL_OWNER\%\%/$RYUJINX_TARGET_RELEASE_CHANNEL_OWNER/g;" src/Ryujinx.Common/ReleaseInformation.cs
     sed -r --in-place "s/\%\%RYUJINX_TARGET_RELEASE_CHANNEL_REPO\%\%/$RYUJINX_TARGET_RELEASE_CHANNEL_REPO/g;" src/Ryujinx.Common/ReleaseInformation.cs
     mkdir -p /app/bin
-    dotnet publish -c Release -r $RUNTIME /p:DebugType=embedded src/Ryujinx /p:Version=$RYUJINX_VERSION /p:SourceRevisionId=$RYUJINX_GIT_SHORT_HASH /p:ExtraDefineConstants="DISABLE_UPDATER%2CFORCE_EXTERNAL_BASE_DIR" /p:RuntimeFrameworkVersion=$RUNTIME_FRAMEWORK_VERSION --self-contained --source nuget-sources
+    dotnet publish -c Release -r $RUNTIME /p:DebugType=embedded src/Ryujinx /p:Version=$RYUJINX_VERSION /p:SourceRevisionId=$RYUJINX_GIT_SHORT_HASH /p:ExtraDefineConstants="DISABLE_UPDATER" /p:RuntimeFrameworkVersion=$RUNTIME_FRAMEWORK_VERSION --self-contained --source nuget-sources
     if [ $? -ne 0 ]; then
         exit 1;
     fi;
@@ -58,6 +58,7 @@ modules:
     ln -s /usr/lib/x86_64-linux-gnu/libX11.so.6 /app/lib/libX11.so
     install -Dm644 $FLATPAK_ID.appdata.xml /app/share/metainfo/$FLATPAK_ID.appdata.xml
     install -Dm755 ryujinx-wrapper /app/bin/ryujinx-wrapper
+    install -Dm755 distribution/linux/Ryujinx.sh /app/bin/Ryujinx.sh
     install -Dm644 distribution/misc/Logo.svg /app/share/icons/hicolor/scalable/apps/ryujinx.svg
     install -Dm644 distribution/linux/mime/Ryujinx.xml /app/share/mime/packages/$FLATPAK_ID.mime.xml
     install -Dm644 distribution/linux/Ryujinx.desktop /app/share/applications/$FLATPAK_ID.desktop

--- a/org.ryujinx.Ryujinx.yml
+++ b/org.ryujinx.Ryujinx.yml
@@ -48,6 +48,7 @@ modules:
     sed -r --in-place "s/\%\%RYUJINX_TARGET_RELEASE_CHANNEL_NAME\%\%/$RYUJINX_TARGET_RELEASE_CHANNEL_NAME/g;" src/Ryujinx.Common/ReleaseInformation.cs
     sed -r --in-place "s/\%\%RYUJINX_TARGET_RELEASE_CHANNEL_OWNER\%\%/$RYUJINX_TARGET_RELEASE_CHANNEL_OWNER/g;" src/Ryujinx.Common/ReleaseInformation.cs
     sed -r --in-place "s/\%\%RYUJINX_TARGET_RELEASE_CHANNEL_REPO\%\%/$RYUJINX_TARGET_RELEASE_CHANNEL_REPO/g;" src/Ryujinx.Common/ReleaseInformation.cs
+    sed -r --in-place 's/\%\%RYUJINX_CONFIG_FILE_NAME\%\%/Config\.json/g;' src/Ryujinx.Common/ReleaseInformation.cs
     mkdir -p /app/bin
     dotnet publish -c Release -r $RUNTIME /p:DebugType=embedded src/Ryujinx /p:Version=$RYUJINX_VERSION /p:SourceRevisionId=$RYUJINX_GIT_SHORT_HASH /p:ExtraDefineConstants="DISABLE_UPDATER" /p:RuntimeFrameworkVersion=$RUNTIME_FRAMEWORK_VERSION --self-contained --source nuget-sources
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
This PR removes the define for `FORCE_EXTERNAL_BASE_DIR` and installs `Ryujinx.sh` which will now also be used by `ryujinx-wrapper`.

In addition to that I added permissions for `xdg-pictures`, so users can save screenshots successfully.

---

Depends on Ryujinx/Ryujinx#4707