### PR TITLE
Add xdg-config permission to fix dark theme

### DIFF
--- a/org.ryujinx.Ryujinx.yml
+++ b/org.ryujinx.Ryujinx.yml
@@ -15,6 +15,7 @@ finish-args:
   - --share=network
   - --filesystem=home:ro
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
+  - --filesystem=xdg-config/gtk-3.0:ro
 rename-icon: ryujinx
 command: ryujinx-wrapper
 modules:


### PR DESCRIPTION
I noticed that by default this app is not themed correctly on my system. This additional permission should resolve the broken theming on some systems.

Tested on my system:
Theme: Breeze Dark (org.gtk.Gtk3theme.Breeze)
Operating System: Arch Linux
KDE Plasma Version: 5.27.7
KDE Frameworks Version: 5.108.0
Qt Version: 5.15.10
Kernel Version: 6.4.9-arch1-1 (64-bit)
Graphics Platform: Wayland